### PR TITLE
Address TRAC-1019

### DIFF
--- a/bepress-to-mods.xq
+++ b/bepress-to-mods.xq
@@ -150,7 +150,7 @@ return file:write(concat($doc-path, 'MODS.xml'),
       group by $f
       count $count
       return
-        <mods:relatedItem type="constituent-1">
+        <mods:relatedItem type="constituent">
           <mods:titleInfo><mods:title>{replace($f, '^\d{1,}-', '')}</mods:title></mods:titleInfo>
           <mods:physicalDescription>
             <mods:internetMediaType>

--- a/bepress-to-mods.xq
+++ b/bepress-to-mods.xq
@@ -189,25 +189,6 @@ return file:write(concat($doc-path, 'MODS.xml'),
             <mods:note displayLabel="supplemental_file">{'SUPPL_' || $count}</mods:note>
           </mods:relatedItem>
       )}
-    {(:for $f in ($file-list)
-      where (replace($f, '^\d{1,}-', ''))[(. = $suppl-archive-name)]
-      group by $f
-      count $count
-      return
-        <mods:relatedItem type="constituent">
-          <mods:titleInfo><mods:title>{replace($f, '^\d{1,}-', '')}</mods:title></mods:titleInfo>
-          <mods:physicalDescription>
-            <mods:internetMediaType>
-              {if (replace($f, '^\d{1,}-', '') = $suppl-archive-name)
-              then ($doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:mime-type/text())
-              else (fetch:content-type(concat($doc-path, $f)))}
-            </mods:internetMediaType>
-          </mods:physicalDescription>
-          {if ($doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description)
-          then (<mods:abstract>{$doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description/text()}</mods:abstract>)
-          else()}
-          <mods:note displayLabel="supplemental_file">{'SUPPL_' || $count}</mods:note>
-        </mods:relatedItem>:)}
 
     <mods:recordInfo displayLabel="Submission">
       <mods:recordCreationDate encoding="w3cdtf">{$sub-date}</mods:recordCreationDate>

--- a/bepress-to-mods.xq
+++ b/bepress-to-mods.xq
@@ -146,12 +146,11 @@ return file:write(concat($doc-path, 'MODS.xml'),
     </mods:relatedItem>
 
     {for $f in ($file-list)
-      where (replace($f, '^\d{1,}-', '')[(not(. = ($suppl-archive-name, $excludes)))])
-        or (replace($f, '^\d{1,}-', '')[(. = $suppl-archive-name)])
+      where (replace($f, '^\d{1,}-', ''))[(. = $suppl-archive-name)]
       group by $f
       count $count
       return
-        <mods:relatedItem type="constituent">
+        <mods:relatedItem type="constituent-1">
           <mods:titleInfo><mods:title>{replace($f, '^\d{1,}-', '')}</mods:title></mods:titleInfo>
           <mods:physicalDescription>
             <mods:internetMediaType>
@@ -161,8 +160,8 @@ return file:write(concat($doc-path, 'MODS.xml'),
             </mods:internetMediaType>
           </mods:physicalDescription>
           {if ($doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description)
-            then (<mods:abstract>{$doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description/text()}</mods:abstract>)
-            else()}
+          then (<mods:abstract>{$doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description/text()}</mods:abstract>)
+          else()}
           <mods:note displayLabel="supplemental_file">{'SUPPL_' || $count}</mods:note>
         </mods:relatedItem>}
 

--- a/bepress-to-mods.xq
+++ b/bepress-to-mods.xq
@@ -145,7 +145,51 @@ return file:write(concat($doc-path, 'MODS.xml'),
       </mods:titleInfo>
     </mods:relatedItem>
 
-    {for $f in ($file-list)
+    {if ($embargo >= xs:date(substring-before($c-date, 'T')))
+      then (
+        for $f in ($file-list)
+        (:where (replace($f, '^\d{1,}-', '')):)
+        where ($f[matches(., '^\d{1,}-')])
+        group by $f
+        count $count
+        return
+          <mods:relatedItem type="constituent">
+            <mods:titleInfo><mods:title>{replace($f, '^\d{1,}-', '')}</mods:title></mods:titleInfo>
+            <mods:physicalDescription>
+              <mods:internetMediaType>
+                {if (replace($f, '^\d{1,}-', '') = $suppl-archive-name)
+                then ($doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:mime-type/text())
+                else (fetch:content-type(concat($doc-path, $f)))}
+              </mods:internetMediaType>
+            </mods:physicalDescription>
+            {if ($doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description)
+            then (<mods:abstract>{$doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description/text()}</mods:abstract>)
+            else()}
+            <mods:note displayLabel="supplemental_file">{'SUPPL_' || $count}</mods:note>
+          </mods:relatedItem>
+      )
+      else (
+        for $f in ($file-list)
+        where (replace($f, '^\d{1,}-', ''))[(. = $suppl-archive-name)]
+        group by $f
+        count $count
+        return
+          <mods:relatedItem type="constituent">
+            <mods:titleInfo><mods:title>{replace($f, '^\d{1,}-', '')}</mods:title></mods:titleInfo>
+            <mods:physicalDescription>
+              <mods:internetMediaType>
+                {if (replace($f, '^\d{1,}-', '') = $suppl-archive-name)
+                then ($doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:mime-type/text())
+                else (fetch:content-type(concat($doc-path, $f)))}
+              </mods:internetMediaType>
+            </mods:physicalDescription>
+            {if ($doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description)
+            then (<mods:abstract>{$doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description/text()}</mods:abstract>)
+            else()}
+            <mods:note displayLabel="supplemental_file">{'SUPPL_' || $count}</mods:note>
+          </mods:relatedItem>
+      )}
+    {(:for $f in ($file-list)
       where (replace($f, '^\d{1,}-', ''))[(. = $suppl-archive-name)]
       group by $f
       count $count
@@ -163,7 +207,7 @@ return file:write(concat($doc-path, 'MODS.xml'),
           then (<mods:abstract>{$doc-content/*:supplemental-files/*:file/*:archive-name[. = replace($f, '^\d{1,}-', '')]/following-sibling::*:description/text()}</mods:abstract>)
           else()}
           <mods:note displayLabel="supplemental_file">{'SUPPL_' || $count}</mods:note>
-        </mods:relatedItem>}
+        </mods:relatedItem>:)}
 
     <mods:recordInfo displayLabel="Submission">
       <mods:recordCreationDate encoding="w3cdtf">{$sub-date}</mods:recordCreationDate>

--- a/sample-data-uris.xml
+++ b/sample-data-uris.xml
@@ -5,4 +5,5 @@
   <doc href="sample-data/1056/metadata.xml"/>
   <doc href="sample-data/0001/metadata.xml"/>
   <doc href="sample-data/3271/metadata.xml"/>
+  <doc href="sample-data/1084/metadata.xml"/>
 </catalog>


### PR DESCRIPTION
JIRA ticket: [TRAC-1019](https://jira.lib.utk.edu/browse/trac-1019)

## What? ##
This PR revises how supplemental files are handled from bepress xml -> MODS xml. 

## WHAT?!? ##
Firstly: *if* an object is embargoed, we will take every file that *appears* to be a supplemental; e.g. everything that starts with `\d{1,}-`.
Secondly: if an object is *not* embargoed, we will only take files (that start with `\d{1,}-`) that are articulated in the bepress xml's `/documents/document/supplemental-files` node.

## How? ##
1. Retrieve this PR.
2. Apply the script to some sample set of bepress metadata.xml
3. Review the output: you *should* have _fewer_ supplemental files, generally speaking, than before.

@robert-patrick-waltz 
