### PR TITLE
Address TRAC-1074: Correct mods:originInfo serialization

### DIFF
--- a/bepress-to-nfp-mods.xq
+++ b/bepress-to-nfp-mods.xq
@@ -87,7 +87,7 @@ return file:write(concat($doc-path, 'MODS.xml'),
       <mods:dateCreated encoding="w3cdtf">{$sub-date}</mods:dateCreated>
       <mods:dateIssued keyDate="yes" encoding="edtf">{$pub-date}</mods:dateIssued>
         {if ($city)
-          then <mods:place>{$city}</mods:place>
+          then <mods:place><mods:placeTerm>{$city}</mods:placeTerm></mods:place>
           else()
         }
         {if ($publisher)


### PR DESCRIPTION
JIRA ticket: [TRAC-1074](https://jira.lib.utk.edu/browse/trac-1074)

What:
This PR adds `mods:placeTerm` to the `mods:originInfo/mods:place` serialization, so, y'know, we're valid.

How to Test:
Generate some MODS, specifically via the NFP xquery, and validate the output. Then switch to this branch and do the same.

Interested Parties:
@markpbaggett 